### PR TITLE
Geolocation-Karte "invalidieren"

### DIFF
--- a/modules/70/1/output.php
+++ b/modules/70/1/output.php
@@ -791,8 +791,9 @@ if(filter_input(INPUT_GET, 'property_id', FILTER_VALIDATE_INT, ['options' => ['d
 			}
 			catch (Exception $e) {}
 
+            $map_id = 'd2u' . md5(strval(time());
 			echo \Geolocation\mapset::take($map_type)
-				->attributes('id', $map_type)
+				->attributes('id', $map_id)
 				->dataset('position', [$property->latitude, $property->longitude])
 				->dataset('center', [[$property->latitude, $property->longitude], 15])
 				->parse();
@@ -1257,6 +1258,12 @@ else {
 					print "L.Util.requestAnimFrame(map.invalidateSize,map,!1,map._container);";
 				}
 				elseif(rex_addon::get('geolocation')->isAvailable()) {
+                    print '
+                    let container = document.getElementById(\''.$map_id.'\');
+                    if( container ) container.__rmMap.map.invalidateSize();
+                    // oder falls da simple invalidateSize nicht reicht:
+                    // if( container ) L.Util.requestAnimFrame(container.__rmMap.map.invalidateSize,container.__rmMap.map,!1,container);  
+                    ';
 //					print "Geolocation.initMap(". $map_type .");"; // FIXME invalidate map size
 				}
 			?>


### PR DESCRIPTION
Zur Erklärung. Die Karte kriegt im mapset-Aufruf eine schicke und garantiert eindeutige ID, die zudem in der PHP-Variablen `$map_id` steht. Über die ID kann der <rex_map>-Tag später einfach lokalisiert werden. Und das passiert dann auch beim Anzeigen des Tabs (`let container = document.getElementById(\''.$map_id.'\');`). Im <rex-map>-Tag (Node in die Variable container geschrieben) steht unter `container.__rmMap` auch die Leaflet-Karte (`container.__rmMap.map`). Also alles da, Map und Container. Versuch doch erst mal, ob ein simples `invalidateSize()`ausreicht, sonst die komplizierte Version. (ungetestet)